### PR TITLE
finish Swamp Willow Tree world gen  

### DIFF
--- a/src/main/java/com/farcr/swampexpansion/common/worldgen/FeatureEditer.java
+++ b/src/main/java/com/farcr/swampexpansion/common/worldgen/FeatureEditer.java
@@ -1,0 +1,15 @@
+package com.farcr.swampexpansion.common.worldgen;
+
+import com.farcr.swampexpansion.core.registries.BlockRegistry;
+import net.minecraft.world.gen.feature.SwampTreeFeature;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+public class FeatureEditer
+{
+    public static void overRideFeatures()
+    {
+        SwampTreeFeature.TRUNK = BlockRegistry.WILLOW_LOG.getDefaultState();
+        SwampTreeFeature.LEAF = BlockRegistry.WILLOW_LEAVES.getDefaultState();
+    }
+}

--- a/src/main/java/com/farcr/swampexpansion/core/SwampExpansion.java
+++ b/src/main/java/com/farcr/swampexpansion/core/SwampExpansion.java
@@ -1,14 +1,17 @@
 package com.farcr.swampexpansion.core;
 
+import com.farcr.swampexpansion.common.worldgen.FeatureEditer;
 import com.farcr.swampexpansion.core.proxy.ClientProxy;
 import com.farcr.swampexpansion.core.proxy.ServerProxy;
 import com.farcr.swampexpansion.core.registries.BlockRegistry;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
 @Mod("swampexpansion")
+@Mod.EventBusSubscriber
 public class SwampExpansion {
     public static ServerProxy proxy = DistExecutor.runForDist(() -> ClientProxy::new, () -> ServerProxy::new);
 
@@ -19,5 +22,11 @@ public class SwampExpansion {
     private void setupCommon(final FMLCommonSetupEvent event) {
         proxy.init();
         BlockRegistry.registerBlockData();
+    }
+
+    @SubscribeEvent
+    void preInit(final FMLCommonSetupEvent event)
+    {
+        FeatureEditer.overRideFeatures();
     }
 }

--- a/src/main/java/com/farcr/swampexpansion/core/SwampExpansion.java
+++ b/src/main/java/com/farcr/swampexpansion/core/SwampExpansion.java
@@ -22,11 +22,12 @@ public class SwampExpansion {
     private void setupCommon(final FMLCommonSetupEvent event) {
         proxy.init();
         BlockRegistry.registerBlockData();
+        FeatureEditer.overRideFeatures();
     }
 
     @SubscribeEvent
     void preInit(final FMLCommonSetupEvent event)
     {
-        FeatureEditer.overRideFeatures();
+
     }
 }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -4,3 +4,5 @@ public net.minecraft.block.TrapDoorBlock <init>(Lnet/minecraft/block/Block$Prope
 protected net.minecraft.entity.item.BoatEntity func_184447_s()V # tickLerp
 public net.minecraft.block.PressurePlateBlock <init>(Lnet/minecraft/block/PressurePlateBlock$Sensitivity;Lnet/minecraft/block/Block$Properties;)V # PressurePlateBlock
 public-f net.minecraft.item.AxeItem field_203176_a # BLOCK_STRIPPING_MAP
+public-f net.minecraft.world.gen.feature.SwampTreeFeature field_181648_a # TRUNK
+public-f net.minecraft.world.gen.feature.SwampTreeFeature field_181649_b # LEAF


### PR DESCRIPTION
the logs and leafs of SwampTreeFeature are made public -final, by the AT. 
Then, from the setupCommon a bunch of code is called that modifies those LOG and LEAF fields to be the willow blocks. So the trees are made from willow wood instead.