### PR TITLE
Enhanced Mushrooms compat

### DIFF
--- a/src/main/java/com/farcr/swampexpansion/common/world/biome/SwampExBiomeFeatures.java
+++ b/src/main/java/com/farcr/swampexpansion/common/world/biome/SwampExBiomeFeatures.java
@@ -34,6 +34,7 @@ import net.minecraft.world.gen.placement.HeightWithChanceConfig;
 import net.minecraft.world.gen.placement.IPlacementConfig;
 import net.minecraft.world.gen.placement.Placement;
 import net.minecraft.world.gen.treedecorator.LeaveVineTreeDecorator;
+import net.minecraftforge.fml.ModList;
 
 public class SwampExBiomeFeatures {
 	public static BlockState WILLOW_LOG = SwampExBlocks.WILLOW_LOG.get().getDefaultState();
@@ -55,7 +56,8 @@ public class SwampExBiomeFeatures {
 			.setSapling((net.minecraftforge.common.IPlantable)SwampExBlocks.WILLOW_SAPLING.get()).build();
 	
 	public static void addMushrooms(Biome biome) {
-		biome.addFeature(GenerationStage.Decoration.VEGETAL_DECORATION, Feature.RANDOM_BOOLEAN_SELECTOR.withConfiguration(new TwoFeatureChoiceConfig(Feature.HUGE_RED_MUSHROOM.withConfiguration(DefaultBiomeFeatures.BIG_RED_MUSHROOM), Feature.HUGE_BROWN_MUSHROOM.withConfiguration(DefaultBiomeFeatures.BIG_BROWN_MUSHROOM))).withPlacement(Placement.COUNT_HEIGHTMAP.configure(new FrequencyConfig(1))));
+		if (!ModList.get().isLoaded("enhanced_mushrooms"))
+			biome.addFeature(GenerationStage.Decoration.VEGETAL_DECORATION, Feature.RANDOM_BOOLEAN_SELECTOR.withConfiguration(new TwoFeatureChoiceConfig(Feature.HUGE_RED_MUSHROOM.withConfiguration(DefaultBiomeFeatures.BIG_RED_MUSHROOM), Feature.HUGE_BROWN_MUSHROOM.withConfiguration(DefaultBiomeFeatures.BIG_BROWN_MUSHROOM))).withPlacement(Placement.COUNT_HEIGHTMAP.configure(new FrequencyConfig(1))));
         biome.addFeature(GenerationStage.Decoration.VEGETAL_DECORATION, Feature.RANDOM_PATCH.withConfiguration(DefaultBiomeFeatures.BROWN_MUSHROOM_CONFIG).withPlacement(Placement.COUNT_CHANCE_HEIGHTMAP.configure(new HeightWithChanceConfig(1, 0.25F))));
         biome.addFeature(GenerationStage.Decoration.VEGETAL_DECORATION, Feature.RANDOM_PATCH.withConfiguration(DefaultBiomeFeatures.RED_MUSHROOM_CONFIG).withPlacement(Placement.COUNT_CHANCE_HEIGHTMAP_DOUBLE.configure(new HeightWithChanceConfig(1, 0.125F))));
 	}


### PR DESCRIPTION
Due to the Forge loading order (or possibly lack thereof) this is the only way I could find to add compatibility with my mod Enhanced Mushrooms. Basically it just disables adding mushrooms on SwampEx's end when EnMush is present, then EnMush readds it on its end (using the custom EnMush stems) if SwampEx is present.

Should work perfectly as long as you've got Enhanced Mushrooms v1.0.1 or above.